### PR TITLE
Use trim_start_matches instead of deprecated trim_left_matches

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -46,7 +46,7 @@ pub(crate) fn parse(range: Option<&HeaderValue>, len: u64) -> ResolvedRanges {
     let mut ranges: SmallVec<[Range<u64>; 1]> = SmallVec::new();
     for r in range[6..].split(',') {
         // Trim OWS = *( SP / HTAB )
-        let r = r.trim_left_matches(|c| c == ' ' || c == '\t');
+        let r = r.trim_start_matches(|c| c == ' ' || c == '\t');
 
         // Parse one of the following.
         // byte-range-spec = first-byte-pos "-" [ last-byte-pos ]


### PR DESCRIPTION
First of all, thanks for a nice library!

This pull request is just a minor fix for avoiding the following warning.
I got this warning when I build the example.

```
warning: use of deprecated item 'core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`
  --> src/range.rs:49:19
   |
49 |         let r = r.trim_left_matches(|c| c == ' ' || c == '\t');
   |                   ^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(deprecated)] on by default
```