### PR TITLE
Remove Sync bound for Body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
+checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -548,8 +548,8 @@ dependencies = [
  "httparse",
  "itoa",
  "log",
- "net2",
  "pin-project",
+ "socket2",
  "time 0.1.43",
  "tokio",
  "tower-service",

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -41,7 +41,7 @@ where
 {
     pub(crate) fn with_chunk_size(
         cap: usize,
-    ) -> (Self, Box<dyn Stream<Item = Result<D, E>> + Send + Sync>) {
+    ) -> (Self, Box<dyn Stream<Item = Result<D, E>> + Send>) {
         assert!(cap > 0);
         let (snd, rcv) = mpsc::unbounded();
         let body = Box::new(rcv);
@@ -120,7 +120,7 @@ mod tests {
     use std::pin::Pin;
 
     type BoxedError = Box<dyn std::error::Error + 'static + Send + Sync>;
-    type BodyStream = Box<dyn Stream<Item = Result<Vec<u8>, BoxedError>> + Send + Sync>;
+    type BodyStream = Box<dyn Stream<Item = Result<Vec<u8>, BoxedError>> + Send>;
 
     async fn to_vec(s: BodyStream) -> Vec<u8> {
         Pin::from(s).try_concat().await.unwrap()

--- a/src/file.rs
+++ b/src/file.rs
@@ -182,7 +182,7 @@ mod tests {
     type BoxedError = Box<dyn std::error::Error + Sync + Send>;
     type CRF = ChunkedReadFile<Bytes, BoxedError>;
 
-    async fn to_bytes(s: Box<dyn Stream<Item = Result<Bytes, BoxedError>> + Send + Sync>) -> Bytes {
+    async fn to_bytes(s: Box<dyn Stream<Item = Result<Bytes, BoxedError>> + Send>) -> Bytes {
         hyper::body::to_bytes(hyper::Body::from(s)).await.unwrap()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ fn parse_qvalue(s: &str) -> Result<u16, ()> {
         "1" | "1." | "1.0" | "1.00" | "1.000" => return Ok(1000),
         "0" | "0." => return Ok(0),
         s if !s.starts_with("0.") => return Err(()),
-        _ => {},
+        _ => {}
     };
     let v = &s[2..];
     let factor = match v.len() {
@@ -277,7 +277,7 @@ impl StreamingBodyBuilder {
     where
         D: From<Vec<u8>> + Send + Sync,
         E: Send + Sync,
-        P: From<Box<dyn Stream<Item = Result<D, E>> + Send + Sync>>,
+        P: From<Box<dyn Stream<Item = Result<D, E>> + Send>>,
     {
         let (w, stream) = chunker::BodyWriter::with_chunk_size(self.chunk_size);
         let mut resp = http::Response::new(stream.into());

--- a/src/serving.rs
+++ b/src/serving.rs
@@ -55,18 +55,18 @@ fn parse_modified_hdrs(
     Ok((precondition_failed, not_modified))
 }
 
-fn static_body<D, E>(s: &'static str) -> Box<dyn Stream<Item = Result<D, E>> + Send + Sync>
+fn static_body<D, E>(s: &'static str) -> Box<dyn Stream<Item = Result<D, E>> + Send>
 where
-    D: 'static + Send + Sync + Buf + From<Vec<u8>> + From<&'static [u8]>,
-    E: 'static + Send + Sync,
+    D: 'static + Send + Buf + From<Vec<u8>> + From<&'static [u8]>,
+    E: 'static + Send,
 {
     Box::new(stream::once(futures::future::ok(s.as_bytes().into())))
 }
 
-fn empty_body<D, E>() -> Box<dyn Stream<Item = Result<D, E>> + Send + Sync>
+fn empty_body<D, E>() -> Box<dyn Stream<Item = Result<D, E>> + Send>
 where
-    D: 'static + Send + Sync + Buf + From<Vec<u8>> + From<&'static [u8]>,
-    E: 'static + Send + Sync,
+    D: 'static + Send + Buf + From<Vec<u8>> + From<&'static [u8]>,
+    E: 'static + Send,
 {
     Box::new(stream::empty())
 }
@@ -77,7 +77,7 @@ where
 /// `Expires`, `Cache-Control`, and `Vary` headers if desired.
 pub fn serve<
     Ent: Entity,
-    B: Body + From<Box<dyn Stream<Item = Result<Ent::Data, Ent::Error>> + Send + Sync>>,
+    B: Body + From<Box<dyn Stream<Item = Result<Ent::Data, Ent::Error>> + Send>>,
     BI,
 >(
     entity: Ent,
@@ -97,8 +97,7 @@ pub fn serve<
                 next_multipart_body_chunk(state, &entity, &ranges[..], &mut part_headers[..])
             });
             let body = bodies.flatten();
-            let body: Box<dyn Stream<Item = Result<Ent::Data, Ent::Error>> + Send + Sync> =
-                Box::new(body);
+            let body: Box<dyn Stream<Item = Result<Ent::Data, Ent::Error>> + Send> = Box::new(body);
             res.body(body.into()).unwrap()
         }
     }
@@ -118,7 +117,7 @@ enum ServeInner<B> {
 fn serve_inner<
     D: 'static + Send + Sync + Buf + From<Vec<u8>> + From<&'static [u8]>,
     E: 'static + Send + Sync,
-    B: Body + From<Box<dyn Stream<Item = Result<D, E>> + Send + Sync>>,
+    B: Body + From<Box<dyn Stream<Item = Result<D, E>> + Send>>,
     BI,
 >(
     ent: &dyn Entity<Error = E, Data = D>,


### PR DESCRIPTION
Update for https://github.com/hyperium/hyper/pull/2187.

TBH, bounds like

```rust
impl<D, E> Entity for ChunkedReadFile<D, E>
where
    D: 'static + Send + Sync + Buf + From<Vec<u8>> + From<&'static [u8]>,
    E: 'static
        + Send
        + Sync
        + Into<Box<dyn StdError + Send + Sync>>
        + From<Box<dyn StdError + Send + Sync>>,
```

aren't exactly easy to understand or work with. Maybe it's worth using `Body` instead?